### PR TITLE
use a method of sanitization that doesn't require column

### DIFF
--- a/lib/active_record/database_mutex/implementation.rb
+++ b/lib/active_record/database_mutex/implementation.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       # Unlocks the mutex and returns true if successful. Otherwise this method
       # raises a MutexLocked exception.
       def unlock(*)
-        case query("SELECT RELEASE_LOCK(#{ActiveRecord::Base.quote_value(name)})")
+        case query("SELECT RELEASE_LOCK(#{ActiveRecord::Base.sanitize(name)})")
         when 1      then true
         when 0, nil then raise MutexUnlockFailed, "unlocking of mutex '#{name}' failed"
         end
@@ -61,7 +61,7 @@ module ActiveRecord
 
       # Returns true if this mutex is unlocked at the moment.
       def unlocked?
-        query("SELECT IS_FREE_LOCK(#{ActiveRecord::Base.quote_value(name)})") == 1
+        query("SELECT IS_FREE_LOCK(#{ActiveRecord::Base.sanitize(name)})") == 1
       end
 
       # Returns true if this mutex is locked at the moment.
@@ -71,7 +71,7 @@ module ActiveRecord
 
       # Returns true if this mutex is locked by this database connection.
       def aquired_lock?
-        query("SELECT CONNECTION_ID() = IS_USED_LOCK(#{ActiveRecord::Base.quote_value(name)})") == 1
+        query("SELECT CONNECTION_ID() = IS_USED_LOCK(#{ActiveRecord::Base.sanitize(name)})") == 1
       end
 
       # Returns true if this mutex is not locked by this database connection.
@@ -90,7 +90,7 @@ module ActiveRecord
 
       def lock_with_timeout(opts = {})
         timeout = opts[:timeout] || 1
-        case query("SELECT GET_LOCK(#{ActiveRecord::Base.quote_value(name)}, #{timeout})")
+        case query("SELECT GET_LOCK(#{ActiveRecord::Base.sanitize(name)}, #{timeout})")
         when 1 then true
         when 0 then raise MutexLocked, "mutex '#{name}' is already locked"
         end


### PR DESCRIPTION
According to following commit https://github.com/rails/rails/commit/31a43ebc107fbd50e7e62567e5208a05909ec76c the gem shouldn't use method quote_value anymore to be compatible with newest versions of rails/active_record. So it has been replaced to most appropriate one of Saitization.